### PR TITLE
Add boundary data generator

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,12 +11,35 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --workspace --verbose
     - name: Run tests
       run: cargo test --workspace --verbose
+
+  generator-binaries:
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: country-boundaries-generator-linux-x86_64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: country-boundaries-generator-macos-aarch64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build generator
+      run: cargo build --release -p country-boundaries-generator --target ${{ matrix.target }}
+    - name: Upload binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.artifact }}
+        path: target/${{ matrix.target }}/release/country-boundaries-generator

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Build
       run: cargo build --workspace --verbose
     - name: Run tests
@@ -35,11 +35,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Build generator
       run: cargo build --release -p country-boundaries-generator --target ${{ matrix.target }}
     - name: Upload binary
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.artifact }}
         path: target/${{ matrix.target }}/release/country-boundaries-generator

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ keywords = ["geocoding", "openstreetmap"]
 [workspace]
 members = [
     "bench",
+    "generator",
 ]

--- a/README.md
+++ b/README.md
@@ -77,14 +77,40 @@ The default data is generated from
 it is licensed under the [Open Database License](https://opendatacommons.org/licenses/odbl/) (ODbL),
 © OpenStreetMap contributors. If you use it, attribution is required.
 
-You can also instead generate an own (country) boundaries file from a GeoJson or an
-[OSM XML](https://wiki.openstreetmap.org/wiki/OSM_XML), using the Java shell application in the
-`/generator/` folder of the [Java project](https://github.com/westnordost/countryboundaries) and use that. For example, 
+You can also generate your own boundaries file from a GeoJSON or an
+[OSM XML](https://wiki.openstreetmap.org/wiki/OSM_XML) using the included `generator/` tool (see below),
+or using the Java shell application in the
+[Java project](https://github.com/westnordost/countryboundaries). For example,
 Natural Earth data is public domain.
+
+## Generator
+
+The `generator/` directory contains a CLI tool that creates boundaries data files from GeoJSON or
+JOSM boundaries OSM XML files.
+
+```sh
+# Build the generator
+cargo build --release -p country-boundaries-generator
+
+# Generate from the JOSM boundaries file
+./target/release/country-boundaries-generator boundaries.osm 360 180
+
+# Generate from a GeoJSON file
+./target/release/country-boundaries-generator boundaries.geojson 360 180
+```
+
+This produces a `boundaries.ser` file that can be loaded with `CountryBoundaries::from_reader`.
+
+The GeoJSON input must be a FeatureCollection where each Feature has a Polygon or MultiPolygon
+geometry and a properties object with an `"id"` field containing the area identifier (e.g. `"US"`,
+`"DE"`, `"US-TX"`).
+
+The two numeric arguments are the raster width and height. Larger values produce bigger files but
+faster queries. Common choices are `360 180`, `180 90`, or `60 30`.
 
 ## Default data
 For your convenience, the default data is included in the distribution as bytes which you can access via the constants
-`BOUNDARIES_ODBL_360X180`, `BOUNDARIES_ODBL_180X60` or `BOUNDARIES_ODBL_60X30`. (The linker ensures that only the
+`BOUNDARIES_ODBL_360X180`, `BOUNDARIES_ODBL_180X90` or `BOUNDARIES_ODBL_60X30`. (The linker ensures that only the
 constants you use are actually included in the executable). 
 It's all the same data, only different 
 raster sizes: The bigger the raster, the bigger the file size but also the faster the queries, see the next section 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,7 @@ it is licensed under the [Open Database License](https://opendatacommons.org/lic
 © OpenStreetMap contributors. If you use it, attribution is required.
 
 You can also generate your own boundaries file from a GeoJSON or an
-[OSM XML](https://wiki.openstreetmap.org/wiki/OSM_XML) using the included `generator/` tool (see below),
-or using the Java shell application in the
-[Java project](https://github.com/westnordost/countryboundaries). For example,
-Natural Earth data is public domain.
+[OSM XML](https://wiki.openstreetmap.org/wiki/OSM_XML) using the included `generator/` tool (see below). For example, Natural Earth data is public domain.
 
 ## Generator
 

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "country-boundaries-generator"
+version = "0.1.0"
+edition = "2021"
+description = "Generate country-boundaries data files from GeoJSON or OSM XML"
+
+[dependencies]
+geo = "0.29"
+geojson = "0.24"
+quick-xml = "0.37"
+
+[dev-dependencies]
+country-boundaries = { path = ".." }
+tempfile = "3"

--- a/generator/src/compare.rs
+++ b/generator/src/compare.rs
@@ -1,0 +1,83 @@
+/// Compare two CountryBoundaries instances cell by cell, reporting differences.
+#[cfg(test)]
+pub mod tests {
+    use country_boundaries::{CountryBoundaries, LatLon};
+    use std::collections::HashSet;
+
+    /// Compare the query results of two boundaries instances over a grid of test points.
+    /// Returns a list of (lat, lon, ids_a, ids_b) for points where they differ.
+    pub fn compare_query_results(
+        a: &CountryBoundaries,
+        b: &CountryBoundaries,
+    ) -> Vec<(f64, f64, Vec<String>, Vec<String>)> {
+        let mut diffs = Vec::new();
+        // Test at 1-degree intervals
+        let mut lat = -89.5;
+        while lat <= 89.5 {
+            let mut lon = -179.5;
+            while lon <= 179.5 {
+                let pos = LatLon::new(lat, lon).unwrap();
+                let ids_a: Vec<String> = a.ids(pos).iter().map(|s| s.to_string()).collect();
+                let ids_b: Vec<String> = b.ids(pos).iter().map(|s| s.to_string()).collect();
+
+                // Compare as sets (order may differ due to geometry_sizes HashMap ordering)
+                let set_a: HashSet<&str> = ids_a.iter().map(|s| s.as_str()).collect();
+                let set_b: HashSet<&str> = ids_b.iter().map(|s| s.as_str()).collect();
+
+                if set_a != set_b {
+                    diffs.push((lat, lon, ids_a, ids_b));
+                }
+
+                lon += 1.0;
+            }
+            lat += 1.0;
+        }
+        diffs
+    }
+
+    #[test]
+    fn kotlin_and_rust_generators_produce_same_results() {
+        let kotlin_path = "/tmp/boundaries.ser";
+        let rust_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../boundaries.ser");
+
+        let kotlin_data = match std::fs::read(kotlin_path) {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("Skipping comparison test: cannot read {kotlin_path}: {e}");
+                eprintln!("Run the Kotlin generator first:");
+                eprintln!("  java -jar generator-all.jar boundaries.osm 180 90");
+                return;
+            }
+        };
+        let rust_data = match std::fs::read(rust_path) {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("Skipping comparison test: cannot read {rust_path}: {e}");
+                eprintln!("Run the Rust generator first:");
+                eprintln!("  cargo run --release -p country-boundaries-generator -- boundaries.osm 180 90");
+                return;
+            }
+        };
+
+        let kotlin = CountryBoundaries::from_reader(kotlin_data.as_slice()).unwrap();
+        let rust = CountryBoundaries::from_reader(rust_data.as_slice()).unwrap();
+
+        let diffs = compare_query_results(&kotlin, &rust);
+
+        if !diffs.is_empty() {
+            eprintln!("Found {} points with different results:", diffs.len());
+            for (lat, lon, kotlin_ids, rust_ids) in &diffs[..diffs.len().min(20)] {
+                eprintln!(
+                    "  ({lat}, {lon}): kotlin={kotlin_ids:?} rust={rust_ids:?}"
+                );
+            }
+            if diffs.len() > 20 {
+                eprintln!("  ... and {} more", diffs.len() - 20);
+            }
+            panic!(
+                "Kotlin and Rust generators produced different results at {} points",
+                diffs.len()
+            );
+        }
+    }
+}

--- a/generator/src/geojson_reader.rs
+++ b/generator/src/geojson_reader.rs
@@ -1,0 +1,56 @@
+use crate::NamedArea;
+use geo::MultiPolygon;
+use geojson::GeoJson;
+use std::convert::TryInto;
+
+/// Read named areas from a GeoJSON string.
+///
+/// Expects a FeatureCollection where each Feature has:
+/// - A Polygon or MultiPolygon geometry
+/// - A properties object with an `"id"` field (string)
+pub fn read(input: &str) -> Result<Vec<NamedArea>, Box<dyn std::error::Error>> {
+    let geojson: GeoJson = input.parse()?;
+    let collection = match geojson {
+        GeoJson::FeatureCollection(fc) => fc,
+        _ => return Err("Expected a GeoJSON FeatureCollection".into()),
+    };
+
+    let mut areas = Vec::new();
+
+    for feature in collection.features {
+        let id = feature
+            .properties
+            .as_ref()
+            .and_then(|p| p.get("id"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let id = match id {
+            Some(id) => id,
+            None => continue,
+        };
+
+        let geometry = match feature.geometry {
+            Some(g) => g,
+            None => continue,
+        };
+
+        let multi: Option<MultiPolygon<f64>> = match geometry.value {
+            geojson::Value::Polygon(_) => {
+                let poly: Result<geo::Polygon<f64>, _> = geometry.try_into();
+                poly.ok().map(|p| MultiPolygon(vec![p]))
+            }
+            geojson::Value::MultiPolygon(_) => {
+                let mp: Result<MultiPolygon<f64>, _> = geometry.try_into();
+                mp.ok()
+            }
+            _ => None,
+        };
+
+        if let Some(geometry) = multi {
+            areas.push(NamedArea { id, geometry });
+        }
+    }
+
+    Ok(areas)
+}

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -1,0 +1,261 @@
+mod compare;
+mod geojson_reader;
+mod osm_reader;
+mod tests;
+
+use geo::{
+    Area, BooleanOps, BoundingRect, Coord, Contains, Intersects, MultiPolygon, Polygon, Rect,
+};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::process;
+
+/// A named geometry: an area id and its polygon(s).
+pub struct NamedArea {
+    pub id: String,
+    pub geometry: MultiPolygon<f64>,
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.len() != 4 && args.len() != 3 {
+        eprintln!(
+            "Usage: {} <input.osm|input.geojson> <width> <height>",
+            args[0]
+        );
+        eprintln!("  Generates boundaries.ser from the input file.");
+        eprintln!();
+        eprintln!("  input     OSM XML (.osm) or GeoJSON (.json/.geojson) file");
+        eprintln!("  width     Raster width (e.g. 360)");
+        eprintln!("  height    Raster height (e.g. 180)");
+        process::exit(1);
+    }
+
+    let filename = &args[1];
+    let width: usize = args[2].parse().unwrap_or_else(|e| {
+        eprintln!("Invalid width: {e}");
+        process::exit(1);
+    });
+    let height: usize = args[3].parse().unwrap_or_else(|e| {
+        eprintln!("Invalid height: {e}");
+        process::exit(1);
+    });
+
+    let areas = read_input(filename).unwrap_or_else(|e| {
+        eprintln!("Error reading {filename}: {e}");
+        process::exit(1);
+    });
+
+    let excluded = ["FX", "EU", "AQ"];
+    let areas: Vec<NamedArea> = areas
+        .into_iter()
+        .filter(|a| !excluded.contains(&a.id.as_str()))
+        .collect();
+
+    eprintln!("Read {} areas, generating {width}x{height} raster...", areas.len());
+
+    let data = generate(width, height, &areas);
+
+    let out = File::create("boundaries.ser").unwrap_or_else(|e| {
+        eprintln!("Error creating output file: {e}");
+        process::exit(1);
+    });
+    let mut writer = BufWriter::new(out);
+    writer.write_all(&data).unwrap_or_else(|e| {
+        eprintln!("Error writing output: {e}");
+        process::exit(1);
+    });
+
+    eprintln!("Wrote boundaries.ser");
+}
+
+fn read_input(filename: &str) -> Result<Vec<NamedArea>, Box<dyn std::error::Error>> {
+    if filename.ends_with(".json") || filename.ends_with(".geojson") {
+        let mut contents = String::new();
+        BufReader::new(File::open(filename)?).read_to_string(&mut contents)?;
+        geojson_reader::read(&contents)
+    } else if filename.ends_with(".osm") {
+        let reader = BufReader::new(File::open(filename)?);
+        osm_reader::read(reader)
+    } else {
+        Err("Input file must be .osm, .json, or .geojson".into())
+    }
+}
+
+pub fn generate(width: usize, height: usize, areas: &[NamedArea]) -> Vec<u8> {
+    let geometry_sizes = calculate_geometry_areas(areas);
+
+    let total_cells = width * height;
+    let mut raster_data: Vec<(Vec<String>, Vec<(String, CellPolygon)>)> =
+        Vec::with_capacity(total_cells);
+
+    for y in 0..height {
+        for x in 0..width {
+            let lon_min = -180.0 + 360.0 * x as f64 / width as f64;
+            let lat_max = 90.0 - 180.0 * y as f64 / height as f64;
+            let lon_max = -180.0 + 360.0 * (x + 1) as f64 / width as f64;
+            let lat_min = 90.0 - 180.0 * (y + 1) as f64 / height as f64;
+
+            let cell = create_cell(areas, lon_min, lat_min, lon_max, lat_max);
+            raster_data.push(cell);
+
+            let done = y * width + x + 1;
+            if done % 100 == 0 || done == total_cells {
+                eprint!("\r  {:.1}%", 100.0 * done as f64 / total_cells as f64);
+            }
+        }
+    }
+    eprintln!();
+
+    encode_boundaries(width, &geometry_sizes, &raster_data)
+}
+
+/// Intermediate representation of clipped polygon data for a cell.
+struct CellPolygon {
+    outer: Vec<Vec<(u16, u16)>>,
+    inner: Vec<Vec<(u16, u16)>>,
+}
+
+fn create_cell(
+    areas: &[NamedArea],
+    lon_min: f64,
+    lat_min: f64,
+    lon_max: f64,
+    lat_max: f64,
+) -> (Vec<String>, Vec<(String, CellPolygon)>) {
+    let bounds = Rect::new(
+        Coord { x: lon_min, y: lat_min },
+        Coord { x: lon_max, y: lat_max },
+    );
+    let bounds_poly = bounds.to_polygon();
+
+    let mut containing_ids = Vec::new();
+    let mut intersecting_areas = Vec::new();
+
+    for area in areas {
+        if let Some(bbox) = area.geometry.bounding_rect() {
+            if !Rect::intersects(&bbox, &bounds) {
+                continue;
+            }
+        }
+
+        if area.geometry.contains(&bounds_poly) {
+            containing_ids.push(area.id.clone());
+        } else if area.geometry.intersects(&bounds_poly) {
+            let intersection = area.geometry.intersection(&bounds_poly);
+            for poly in intersection.0 {
+                let cell_poly = polygon_to_cell_coords(&poly, lon_min, lat_min, lon_max, lat_max);
+                intersecting_areas.push((area.id.clone(), cell_poly));
+            }
+        }
+    }
+
+    (containing_ids, intersecting_areas)
+}
+
+fn polygon_to_cell_coords(
+    poly: &Polygon<f64>,
+    lon_min: f64,
+    lat_min: f64,
+    lon_max: f64,
+    lat_max: f64,
+) -> CellPolygon {
+    let to_points = |ring: &geo::LineString<f64>| -> Vec<(u16, u16)> {
+        // Skip last coord (same as first, but the binary format doesn't store the closing point)
+        let coords = ring.coords().collect::<Vec<_>>();
+        let n = if coords.len() > 1 {
+            coords.len() - 1
+        } else {
+            coords.len()
+        };
+        coords[..n]
+            .iter()
+            .map(|c| {
+                let x = ((c.x - lon_min) * 0xffff as f64 / (lon_max - lon_min)) as u16;
+                let y = ((c.y - lat_min) * 0xffff as f64 / (lat_max - lat_min)) as u16;
+                (x, y)
+            })
+            .collect()
+    };
+
+    let outer = vec![to_points(poly.exterior())];
+    let inner = poly.interiors().iter().map(|r| to_points(r)).collect();
+
+    CellPolygon { outer, inner }
+}
+
+fn calculate_geometry_areas(areas: &[NamedArea]) -> HashMap<String, f64> {
+    areas
+        .iter()
+        .map(|a| (a.id.clone(), a.geometry.unsigned_area()))
+        .collect()
+}
+
+/// Encode the raster data into the binary boundaries format.
+fn encode_boundaries(
+    raster_width: usize,
+    geometry_sizes: &HashMap<String, f64>,
+    raster: &[(Vec<String>, Vec<(String, CellPolygon)>)],
+) -> Vec<u8> {
+    let mut buf = Vec::new();
+
+    // version
+    buf.extend_from_slice(&2u16.to_be_bytes());
+
+    // geometry sizes
+    buf.extend_from_slice(&(geometry_sizes.len() as i32).to_be_bytes());
+    for (id, size) in geometry_sizes {
+        write_string_to(&mut buf, id);
+        buf.extend_from_slice(&size.to_be_bytes());
+    }
+
+    // raster width
+    buf.extend_from_slice(&(raster_width as i32).to_be_bytes());
+
+    // raster size
+    buf.extend_from_slice(&(raster.len() as i32).to_be_bytes());
+
+    for (containing_ids, intersecting_areas) in raster {
+        // containing ids
+        buf.push(containing_ids.len() as u8);
+        for id in containing_ids {
+            write_string_to(&mut buf, id);
+        }
+
+        // intersecting areas
+        buf.push(intersecting_areas.len() as u8);
+        for (id, cell_poly) in intersecting_areas {
+            write_string_to(&mut buf, id);
+
+            // outer rings
+            buf.push(cell_poly.outer.len() as u8);
+            for ring in &cell_poly.outer {
+                buf.extend_from_slice(&(ring.len() as i32).to_be_bytes());
+                for &(x, y) in ring {
+                    buf.extend_from_slice(&x.to_be_bytes());
+                    buf.extend_from_slice(&y.to_be_bytes());
+                }
+            }
+
+            // inner rings
+            buf.push(cell_poly.inner.len() as u8);
+            for ring in &cell_poly.inner {
+                buf.extend_from_slice(&(ring.len() as i32).to_be_bytes());
+                for &(x, y) in ring {
+                    buf.extend_from_slice(&x.to_be_bytes());
+                    buf.extend_from_slice(&y.to_be_bytes());
+                }
+            }
+        }
+    }
+
+    buf
+}
+
+fn write_string_to(buf: &mut Vec<u8>, s: &str) {
+    let bytes = s.as_bytes();
+    buf.extend_from_slice(&(bytes.len() as u16).to_be_bytes());
+    buf.extend_from_slice(bytes);
+}

--- a/generator/src/osm_reader.rs
+++ b/generator/src/osm_reader.rs
@@ -1,0 +1,296 @@
+use crate::NamedArea;
+use geo::{Coord, LineString, MultiPolygon, Polygon, Contains};
+use quick_xml::events::Event;
+use quick_xml::Reader;
+use std::collections::HashMap;
+use std::io::BufRead;
+
+/// Read named areas from a JOSM boundaries OSM XML file.
+///
+/// This is the format used by
+/// <https://josm.openstreetmap.de/export/HEAD/josm/trunk/resources/data/boundaries.osm>
+pub fn read(reader: impl BufRead) -> Result<Vec<NamedArea>, Box<dyn std::error::Error>> {
+    let osm = parse_xml(reader)?;
+    let areas = build_areas(&osm);
+    Ok(areas)
+}
+
+struct OsmData {
+    nodes: HashMap<i64, Coord<f64>>,
+    ways: HashMap<i64, Way>,
+    relations: HashMap<i64, Relation>,
+}
+
+struct Way {
+    node_refs: Vec<i64>,
+    name: Option<String>,
+}
+
+struct Relation {
+    outer_way_refs: Vec<i64>,
+    inner_way_refs: Vec<i64>,
+    name: Option<String>,
+}
+
+const ISO3166_1_ALPHA2: &str = "ISO3166-1:alpha2";
+const ISO3166_2: &str = "ISO3166-2";
+
+fn parse_xml(reader: impl BufRead) -> Result<OsmData, Box<dyn std::error::Error>> {
+    let mut xml = Reader::from_reader(reader);
+    let mut buf = Vec::new();
+
+    let mut osm = OsmData {
+        nodes: HashMap::new(),
+        ways: HashMap::new(),
+        relations: HashMap::new(),
+    };
+
+    // Current element being parsed
+    enum Current {
+        None,
+        Way(i64, Way),
+        Relation(i64, Relation),
+    }
+    let mut current = Current::None;
+
+    loop {
+        match xml.read_event_into(&mut buf)? {
+            Event::Eof => break,
+            Event::Start(ref e) | Event::Empty(ref e) => {
+                let name = e.name();
+                match name.as_ref() {
+                    b"node" => {
+                        let mut id = 0i64;
+                        let mut lat = 0.0f64;
+                        let mut lon = 0.0f64;
+                        for attr in e.attributes().flatten() {
+                            match attr.key.as_ref() {
+                                b"id" => {
+                                    id = std::str::from_utf8(&attr.value)?.parse()?;
+                                }
+                                b"lat" => {
+                                    lat = std::str::from_utf8(&attr.value)?.parse()?;
+                                }
+                                b"lon" => {
+                                    lon = std::str::from_utf8(&attr.value)?.parse()?;
+                                }
+                                _ => {}
+                            }
+                        }
+                        osm.nodes.insert(id, Coord { x: lon, y: lat });
+                    }
+                    b"way" => {
+                        let mut id = 0i64;
+                        for attr in e.attributes().flatten() {
+                            if attr.key.as_ref() == b"id" {
+                                id = std::str::from_utf8(&attr.value)?.parse()?;
+                            }
+                        }
+                        current = Current::Way(
+                            id,
+                            Way {
+                                node_refs: Vec::new(),
+                                name: None,
+                            },
+                        );
+                    }
+                    b"relation" => {
+                        let mut id = 0i64;
+                        for attr in e.attributes().flatten() {
+                            if attr.key.as_ref() == b"id" {
+                                id = std::str::from_utf8(&attr.value)?.parse()?;
+                            }
+                        }
+                        current = Current::Relation(
+                            id,
+                            Relation {
+                                outer_way_refs: Vec::new(),
+                                inner_way_refs: Vec::new(),
+                                name: None,
+                            },
+                        );
+                    }
+                    b"nd" => {
+                        if let Current::Way(_, ref mut way) = current {
+                            for attr in e.attributes().flatten() {
+                                if attr.key.as_ref() == b"ref" {
+                                    let r: i64 = std::str::from_utf8(&attr.value)?.parse()?;
+                                    way.node_refs.push(r);
+                                }
+                            }
+                        }
+                    }
+                    b"member" => {
+                        if let Current::Relation(_, ref mut rel) = current {
+                            let mut member_type = Vec::new();
+                            let mut member_ref = 0i64;
+                            let mut role = Vec::new();
+                            for attr in e.attributes().flatten() {
+                                match attr.key.as_ref() {
+                                    b"type" => member_type = attr.value.to_vec(),
+                                    b"ref" => {
+                                        member_ref =
+                                            std::str::from_utf8(&attr.value)?.parse()?;
+                                    }
+                                    b"role" => role = attr.value.to_vec(),
+                                    _ => {}
+                                }
+                            }
+                            if member_type == b"way" {
+                                if role == b"outer" {
+                                    rel.outer_way_refs.push(member_ref);
+                                } else if role == b"inner" {
+                                    rel.inner_way_refs.push(member_ref);
+                                }
+                            }
+                        }
+                    }
+                    b"tag" => {
+                        let mut key = Vec::new();
+                        let mut value = Vec::new();
+                        for attr in e.attributes().flatten() {
+                            match attr.key.as_ref() {
+                                b"k" => key = attr.value.to_vec(),
+                                b"v" => value = attr.value.to_vec(),
+                                _ => {}
+                            }
+                        }
+                        let key_str = std::str::from_utf8(&key)?;
+                        let value_str = std::str::from_utf8(&value)?;
+
+                        match current {
+                            Current::Way(_, ref mut way) => {
+                                if key_str == ISO3166_1_ALPHA2
+                                    || (way.name.is_none() && key_str == ISO3166_2)
+                                {
+                                    way.name = Some(value_str.to_string());
+                                }
+                            }
+                            Current::Relation(_, ref mut rel) => {
+                                if key_str == ISO3166_1_ALPHA2
+                                    || (rel.name.is_none() && key_str == ISO3166_2)
+                                {
+                                    rel.name = Some(value_str.to_string());
+                                }
+                            }
+                            Current::None => {}
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Event::End(ref e) => match e.name().as_ref() {
+                b"way" => {
+                    if let Current::Way(id, way) = std::mem::replace(&mut current, Current::None) {
+                        osm.ways.insert(id, way);
+                    }
+                }
+                b"relation" => {
+                    if let Current::Relation(id, rel) =
+                        std::mem::replace(&mut current, Current::None)
+                    {
+                        osm.relations.insert(id, rel);
+                    }
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    Ok(osm)
+}
+
+fn build_areas(osm: &OsmData) -> Vec<NamedArea> {
+    let mut areas = Vec::new();
+
+    // Ways that are closed polygons with a name
+    for way in osm.ways.values() {
+        let name = match &way.name {
+            Some(n) => n.clone(),
+            None => continue,
+        };
+
+        let coords = way_to_coords(way, &osm.nodes);
+        if coords.len() < 4 {
+            continue;
+        }
+
+        let ring = LineString::new(coords);
+        let poly = Polygon::new(ring, vec![]);
+        areas.push(NamedArea {
+            id: name,
+            geometry: MultiPolygon(vec![poly]),
+        });
+    }
+
+    // Relations (multipolygons)
+    for rel in osm.relations.values() {
+        let name = match &rel.name {
+            Some(n) => n.clone(),
+            None => continue,
+        };
+
+        let outer_rings: Vec<LineString<f64>> = rel
+            .outer_way_refs
+            .iter()
+            .filter_map(|id| osm.ways.get(id))
+            .map(|w| LineString::new(way_to_coords(w, &osm.nodes)))
+            .filter(|ls| ls.0.len() >= 4)
+            .collect();
+
+        let inner_rings: Vec<LineString<f64>> = rel
+            .inner_way_refs
+            .iter()
+            .filter_map(|id| osm.ways.get(id))
+            .map(|w| LineString::new(way_to_coords(w, &osm.nodes)))
+            .filter(|ls| ls.0.len() >= 4)
+            .collect();
+
+        if outer_rings.is_empty() {
+            continue;
+        }
+
+        let polygons = if outer_rings.len() == 1 {
+            vec![Polygon::new(outer_rings.into_iter().next().unwrap(), inner_rings)]
+        } else {
+            // Multiple outer rings: assign inner rings to the correct outer ring
+            let mut polys = Vec::new();
+            let mut remaining_inners = inner_rings;
+
+            for outer in &outer_rings {
+                let temp_poly = Polygon::new(outer.clone(), vec![]);
+                let mut holes = Vec::new();
+
+                remaining_inners.retain(|inner| {
+                    if let Some(first) = inner.0.first() {
+                        let point = geo::Point::new(first.x, first.y);
+                        if temp_poly.contains(&point) {
+                            holes.push(inner.clone());
+                            return false;
+                        }
+                    }
+                    true
+                });
+
+                polys.push(Polygon::new(outer.clone(), holes));
+            }
+            polys
+        };
+
+        areas.push(NamedArea {
+            id: name,
+            geometry: MultiPolygon(polygons),
+        });
+    }
+
+    areas
+}
+
+fn way_to_coords(way: &Way, nodes: &HashMap<i64, Coord<f64>>) -> Vec<Coord<f64>> {
+    way.node_refs
+        .iter()
+        .filter_map(|id| nodes.get(id).copied())
+        .collect()
+}

--- a/generator/src/tests.rs
+++ b/generator/src/tests.rs
@@ -1,0 +1,133 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn geojson_reader_ignores_features_without_id() {
+        let geojson = r#"{
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": { "name": "No ID" },
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [[[-10, -10], [10, -10], [10, 10], [-10, 10], [-10, -10]]]
+                    }
+                },
+                {
+                    "type": "Feature",
+                    "properties": {},
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [[[-10, -10], [10, -10], [10, 10], [-10, 10], [-10, -10]]]
+                    }
+                }
+            ]
+        }"#;
+        let areas = crate::geojson_reader::read(geojson).unwrap();
+        assert!(areas.is_empty());
+    }
+
+    #[test]
+    fn geojson_reader_ignores_non_polygon_features() {
+        let geojson = r#"{
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": { "id": "PT" },
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [0, 0]
+                    }
+                },
+                {
+                    "type": "Feature",
+                    "properties": { "id": "LN" },
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": [[0, 0], [1, 1]]
+                    }
+                }
+            ]
+        }"#;
+        let areas = crate::geojson_reader::read(geojson).unwrap();
+        assert!(areas.is_empty());
+    }
+
+    #[test]
+    fn osm_reader_parses_simple_way() {
+        let osm_xml = r#"<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6'>
+  <node id='1' lat='0' lon='0' />
+  <node id='2' lat='10' lon='0' />
+  <node id='3' lat='10' lon='10' />
+  <node id='4' lat='0' lon='10' />
+  <way id='10'>
+    <nd ref='1'/><nd ref='2'/><nd ref='3'/><nd ref='4'/><nd ref='1'/>
+    <tag k='ISO3166-1:alpha2' v='XX'/>
+  </way>
+</osm>"#;
+        let areas = crate::osm_reader::read(osm_xml.as_bytes()).unwrap();
+        assert_eq!(1, areas.len());
+        assert_eq!("XX", areas[0].id);
+    }
+
+    #[test]
+    fn osm_reader_parses_relation() {
+        let osm_xml = r#"<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6'>
+  <node id='1' lat='0' lon='0' />
+  <node id='2' lat='10' lon='0' />
+  <node id='3' lat='10' lon='10' />
+  <node id='4' lat='0' lon='10' />
+  <way id='10'>
+    <nd ref='1'/><nd ref='2'/><nd ref='3'/><nd ref='4'/><nd ref='1'/>
+  </way>
+  <relation id='100'>
+    <member type='way' ref='10' role='outer'/>
+    <tag k='ISO3166-1:alpha2' v='YY'/>
+  </relation>
+</osm>"#;
+        let areas = crate::osm_reader::read(osm_xml.as_bytes()).unwrap();
+        // Should have the relation but not the way (way has no name)
+        assert_eq!(1, areas.len());
+        assert_eq!("YY", areas[0].id);
+    }
+
+    #[test]
+    fn osm_reader_prefers_alpha2_over_iso3166_2() {
+        let osm_xml = r#"<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6'>
+  <node id='1' lat='0' lon='0' />
+  <node id='2' lat='10' lon='0' />
+  <node id='3' lat='10' lon='10' />
+  <node id='4' lat='0' lon='10' />
+  <way id='10'>
+    <nd ref='1'/><nd ref='2'/><nd ref='3'/><nd ref='4'/><nd ref='1'/>
+    <tag k='ISO3166-2' v='US-TX'/>
+    <tag k='ISO3166-1:alpha2' v='US'/>
+  </way>
+</osm>"#;
+        let areas = crate::osm_reader::read(osm_xml.as_bytes()).unwrap();
+        assert_eq!(1, areas.len());
+        assert_eq!("US", areas[0].id);
+    }
+
+    #[test]
+    fn osm_reader_uses_iso3166_2_as_fallback() {
+        let osm_xml = r#"<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6'>
+  <node id='1' lat='0' lon='0' />
+  <node id='2' lat='10' lon='0' />
+  <node id='3' lat='10' lon='10' />
+  <node id='4' lat='0' lon='10' />
+  <way id='10'>
+    <nd ref='1'/><nd ref='2'/><nd ref='3'/><nd ref='4'/><nd ref='1'/>
+    <tag k='ISO3166-2' v='US-TX'/>
+  </way>
+</osm>"#;
+        let areas = crate::osm_reader::read(osm_xml.as_bytes()).unwrap();
+        assert_eq!(1, areas.len());
+        assert_eq!("US-TX", areas[0].id);
+    }
+}

--- a/generator/tests/integration_test.rs
+++ b/generator/tests/integration_test.rs
@@ -1,0 +1,224 @@
+use country_boundaries::{CountryBoundaries, LatLon};
+use std::collections::HashSet;
+use std::process::Command;
+
+fn latlon(lat: f64, lon: f64) -> LatLon {
+    LatLon::new(lat, lon).unwrap()
+}
+
+fn generator_bin() -> String {
+    // cargo test builds the binary into the deps directory; use cargo_bin_exe convention
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // remove test binary name
+    path.pop(); // remove "deps"
+    path.push("country-boundaries-generator");
+    path.to_str().unwrap().to_string()
+}
+
+fn run_generator(input_path: &str, width: u32, height: u32, work_dir: &std::path::Path) -> Vec<u8> {
+    let output = Command::new(generator_bin())
+        .args([input_path, &width.to_string(), &height.to_string()])
+        .current_dir(work_dir)
+        .output()
+        .expect("failed to run generator");
+
+    if !output.status.success() {
+        panic!(
+            "generator failed with status {}:\nstderr: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    std::fs::read(work_dir.join("boundaries.ser"))
+        .expect("generator did not produce boundaries.ser")
+}
+
+#[test]
+fn generate_from_geojson_and_query() {
+    let geojson = r#"{
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": { "id": "DE" },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[5, 47], [15, 47], [15, 55], [5, 55], [5, 47]]]
+                }
+            },
+            {
+                "type": "Feature",
+                "properties": { "id": "FR" },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[-5, 42], [8, 42], [8, 51], [-5, 51], [-5, 42]]]
+                }
+            }
+        ]
+    }"#;
+
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("test.geojson");
+    std::fs::write(&input, geojson).unwrap();
+
+    let data = run_generator(input.to_str().unwrap(), 60, 30, dir.path());
+    let boundaries = CountryBoundaries::from_reader(data.as_slice()).unwrap();
+
+    // Center of Germany-only area
+    assert_eq!(vec!["DE"], boundaries.ids(latlon(52.0, 13.0)));
+
+    // Center of France-only area
+    assert_eq!(vec!["FR"], boundaries.ids(latlon(45.0, 2.0)));
+
+    // Overlap region (both DE and FR cover parts of 47-51°N, 5-8°E)
+    let ids: HashSet<&str> = boundaries.ids(latlon(49.0, 7.0)).into_iter().collect();
+    assert!(ids.contains("DE"));
+    assert!(ids.contains("FR"));
+
+    // Outside both
+    assert!(boundaries.ids(latlon(0.0, 0.0)).is_empty());
+}
+
+#[test]
+fn generate_from_osm_xml_and_query() {
+    let osm_xml = r#"<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6'>
+  <node id='1' lat='-10' lon='-10' />
+  <node id='2' lat='10' lon='-10' />
+  <node id='3' lat='10' lon='10' />
+  <node id='4' lat='-10' lon='10' />
+  <node id='11' lat='20' lon='20' />
+  <node id='12' lat='40' lon='20' />
+  <node id='13' lat='40' lon='40' />
+  <node id='14' lat='20' lon='40' />
+  <way id='100'>
+    <nd ref='1'/><nd ref='2'/><nd ref='3'/><nd ref='4'/><nd ref='1'/>
+    <tag k='ISO3166-1:alpha2' v='XX'/>
+  </way>
+  <way id='200'>
+    <nd ref='11'/><nd ref='12'/><nd ref='13'/><nd ref='14'/><nd ref='11'/>
+    <tag k='ISO3166-2' v='YY-ZZ'/>
+  </way>
+</osm>"#;
+
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("test.osm");
+    std::fs::write(&input, osm_xml).unwrap();
+
+    let data = run_generator(input.to_str().unwrap(), 60, 30, dir.path());
+    let boundaries = CountryBoundaries::from_reader(data.as_slice()).unwrap();
+
+    assert_eq!(vec!["XX"], boundaries.ids(latlon(0.0, 0.0)));
+    assert_eq!(vec!["YY-ZZ"], boundaries.ids(latlon(30.0, 30.0)));
+    assert!(boundaries.ids(latlon(60.0, 60.0)).is_empty());
+}
+
+#[test]
+fn generate_excludes_non_country_ids() {
+    // FX, EU, AQ should be excluded by the generator
+    let geojson = r#"{
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": { "id": "FX" },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[-10, -10], [10, -10], [10, 10], [-10, 10], [-10, -10]]]
+                }
+            },
+            {
+                "type": "Feature",
+                "properties": { "id": "EU" },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[-10, -10], [10, -10], [10, 10], [-10, 10], [-10, -10]]]
+                }
+            },
+            {
+                "type": "Feature",
+                "properties": { "id": "AQ" },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[-90, -90], [90, -90], [90, 90], [-90, 90], [-90, -90]]]
+                }
+            },
+            {
+                "type": "Feature",
+                "properties": { "id": "DE" },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[-10, -10], [10, -10], [10, 10], [-10, 10], [-10, -10]]]
+                }
+            }
+        ]
+    }"#;
+
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("test.geojson");
+    std::fs::write(&input, geojson).unwrap();
+
+    let data = run_generator(input.to_str().unwrap(), 6, 3, dir.path());
+    let boundaries = CountryBoundaries::from_reader(data.as_slice()).unwrap();
+
+    // Only DE should be present
+    assert_eq!(vec!["DE"], boundaries.ids(latlon(0.0, 0.0)));
+}
+
+#[test]
+fn generate_handles_multipolygon_geojson() {
+    let geojson = r#"{
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": { "id": "IS" },
+                "geometry": {
+                    "type": "MultiPolygon",
+                    "coordinates": [
+                        [[[-30, -30], [-10, -30], [-10, -10], [-30, -10], [-30, -30]]],
+                        [[[10, 10], [30, 10], [30, 30], [10, 30], [10, 10]]]
+                    ]
+                }
+            }
+        ]
+    }"#;
+
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("test.geojson");
+    std::fs::write(&input, geojson).unwrap();
+
+    let data = run_generator(input.to_str().unwrap(), 60, 30, dir.path());
+    let boundaries = CountryBoundaries::from_reader(data.as_slice()).unwrap();
+
+    // Both disjoint parts should be recognized
+    assert_eq!(vec!["IS"], boundaries.ids(latlon(-20.0, -20.0)));
+    assert_eq!(vec!["IS"], boundaries.ids(latlon(20.0, 20.0)));
+    // Gap between them
+    assert!(boundaries.ids(latlon(0.0, 0.0)).is_empty());
+}
+
+#[test]
+fn generate_invalid_input_exits_nonzero() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("test.txt");
+    std::fs::write(&input, "not valid").unwrap();
+
+    let output = Command::new(generator_bin())
+        .args([input.to_str().unwrap(), "6", "3"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to run generator");
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn generate_missing_args_exits_nonzero() {
+    let output = Command::new(generator_bin())
+        .output()
+        .expect("failed to run generator");
+
+    assert!(!output.status.success());
+}


### PR DESCRIPTION
Port the generator from the Kotlin project. The generator reads GeoJSON or JOSM OSM XML and produces the binary boundaries format. Verified to produce identical query results to the Kotlin generator.